### PR TITLE
optparse: fix hanging when option if followed by LF instead of text

### DIFF
--- a/lib/optparse/init.lua
+++ b/lib/optparse/init.lua
@@ -643,7 +643,7 @@ local function _init (self, spec)
   -- Collect helptext lines that begin with two or more spaces followed
   -- by a '-'.
   local specs = {}
-  parser.helptext:gsub ("\n  %s*(%-[^\n]+)",
+  parser.helptext:gsub ("\n  %s*(%-[^\n]+\n?)",
                         function (spec) table_insert (specs, spec) end)
 
   -- Register option handlers according to the help text.


### PR DESCRIPTION
The parser hangs when options in help message are formated like this:

    -u, --name=NAME
        require an argument

instead of:

    -u, --name=NAME  require an argument